### PR TITLE
Add typescript compilation to eslint steps

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "start": "ts-node-esm src/index.ts",
     "test": "echo \"Error: no test specified\" && exit 1",
-    "lint": "npx eslint . --ext .js,.jsx,.ts,.tsx"
+    "lint": "eslint --ext .js,.ts . && tsc --noemit"
   },
   "author": "ArmandBernard",
   "license": "MIT",


### PR DESCRIPTION
This will ensure all types are properly checked.

ESlint's typescript plugin does not appear to cut it.