### PR TITLE
Don't count own messages

### DIFF
--- a/src/bots/WordCounter/WordCounter.test.ts
+++ b/src/bots/WordCounter/WordCounter.test.ts
@@ -10,8 +10,12 @@ const expectedParsedWords = [
 
 const botId = "12345";
 
-const makeMsg = (content: string, id?: string): Message => {
-  return { content, author: { id } } as Message;
+const makeMsg = (content: string, id?: string, has = false): Message => {
+  return {
+    content,
+    author: { id },
+    mentions: { has: (_a, _b) => has },
+  } as Message;
 };
 
 const messageParserCases: [string, string, boolean, string][] = [
@@ -62,6 +66,15 @@ describe("WordCounter", () => {
     it("returns false because the bot is the author", () => {
       expect(
         WordCounter.checkMessage(makeMsg("word", botId), "word", botId)
+      ).toBe(false);
+    });
+    it("returns false if the bot is mentioned", () => {
+      expect(
+        WordCounter.checkMessage(
+          makeMsg("word", undefined, true),
+          "word",
+          botId
+        )
       ).toBe(false);
     });
   });

--- a/src/bots/WordCounter/WordCounter.test.ts
+++ b/src/bots/WordCounter/WordCounter.test.ts
@@ -8,8 +8,10 @@ const expectedParsedWords = [
   ["HQW£%U£J$%^J", "HQW£%U£J$%^J"],
 ];
 
-const makeMsg = (content: string): Message => {
-  return { content } as Message;
+const botId = "12345";
+
+const makeMsg = (content: string, id?: string): Message => {
+  return { content, author: { id } } as Message;
 };
 
 const messageParserCases: [string, string, boolean, string][] = [
@@ -52,10 +54,15 @@ describe("WordCounter", () => {
     it.each(messageParserCases)(
       "When given '%s' and looking for '%s', it returns '%s' because %s.",
       (message, search, expectedResult) => {
-        expect(WordCounter.checkMessage(makeMsg(message), search)).toBe(
+        expect(WordCounter.checkMessage(makeMsg(message), search, botId)).toBe(
           expectedResult
         );
       }
     );
+    it("returns false because the bot is the author", () => {
+      expect(
+        WordCounter.checkMessage(makeMsg("word", botId), "word", botId)
+      ).toBe(false);
+    });
   });
 });

--- a/src/bots/WordCounter/WordCounter.ts
+++ b/src/bots/WordCounter/WordCounter.ts
@@ -90,13 +90,17 @@ export class WordCounter extends BotBase {
     request: string,
     myId: string
   ): boolean => {
-    if (message.author.id === myId) {
+    // early return if this bot is the author or the bot is mentioned
+    if (message.author.id === myId || message.mentions.has(myId)) {
       return false;
     }
+    // escape the request so it cna be safely put in regex
     const escapedRequest = this.escapeRegex(request);
 
+    // create the search regex
     const containsRequest = new RegExp(`(^|\\W)${escapedRequest}(\\W|$)`, "i");
 
+    // check the message
     return containsRequest.test(message.content);
   };
 

--- a/src/bots/WordCounter/WordCounter.ts
+++ b/src/bots/WordCounter/WordCounter.ts
@@ -49,7 +49,7 @@ export class WordCounter extends BotBase {
         // parse their request
         const request = WordCounter.parseRequest(message.content);
 
-        const reply = await WordCounter.prepareReply(message, request);
+        const reply = await WordCounter.prepareReply(message, request, this.id);
 
         this.sendReply(reply, message.channel);
       }
@@ -85,7 +85,14 @@ export class WordCounter extends BotBase {
     return str.replace(/[-/\\^$*+?.()|[\]{}]/g, "\\$&");
   }
 
-  static checkMessage = (message: Message, request: string): boolean => {
+  static checkMessage = (
+    message: Message,
+    request: string,
+    myId: string
+  ): boolean => {
+    if (message.author.id === myId) {
+      return false;
+    }
     const escapedRequest = this.escapeRegex(request);
 
     const containsRequest = new RegExp(`(^|\\W)${escapedRequest}(\\W|$)`, "i");
@@ -95,7 +102,8 @@ export class WordCounter extends BotBase {
 
   static async prepareReply(
     message: Message,
-    request: string
+    request: string,
+    myId: string
   ): Promise<string> {
     // get all messages
     const messages = (await message.channel.messages.fetch({
@@ -103,7 +111,7 @@ export class WordCounter extends BotBase {
     })) as Collection<string, Message>;
 
     const filtered = messages.filter((m) =>
-      WordCounter.checkMessage(m, request)
+      WordCounter.checkMessage(m, request, myId)
     );
 
     if (message.channel.type === ChannelType.DM) {


### PR DESCRIPTION
Make the WordCounter bot not count:
- its own messages 
- any message where it is mentioned (i.e. a request)