### PR TITLE
Fetch more messages with WordCounter

### DIFF
--- a/src/Services/MessageFetcher.ts
+++ b/src/Services/MessageFetcher.ts
@@ -1,0 +1,51 @@
+import { Collection, Message, TextChannel } from "discord.js";
+
+export class MessageFetcher {
+  static async getAllMessages(
+    channel: TextChannel,
+    condition: (message: Message) => boolean,
+    dateLimit: Date
+  ): Promise<Message[]> {
+    let allMessages: Message[] = [];
+
+    // get first message
+    let startFromMessage = (
+      (await channel.messages.fetch({
+        limit: 1,
+      })) as Collection<string, Message>
+    ).first();
+
+    // return early if there are somehow no messages found
+    if (!startFromMessage) {
+      return [];
+    }
+
+    // if condition applies and we are not past date limit, add to array
+    if (
+      condition(startFromMessage) &&
+      startFromMessage.createdAt >= dateLimit
+    ) {
+      allMessages = allMessages.concat([startFromMessage]);
+    }
+
+    // keep getting more messages until the target date is reached
+    while (startFromMessage && startFromMessage.createdAt > dateLimit) {
+      // get previous 100 messages
+      const messages = (await channel.messages.fetch({
+        limit: 100,
+      })) as Collection<string, Message>;
+
+      // add all valid items to all messages
+      allMessages = allMessages.concat(
+        ...messages
+          .filter((m) => condition(m) && m.createdAt > dateLimit)
+          .values()
+      );
+
+      // get new limit message
+      startFromMessage = messages.last();
+    }
+
+    return allMessages;
+  }
+}

--- a/src/Services/MessageFetcher.ts
+++ b/src/Services/MessageFetcher.ts
@@ -1,4 +1,4 @@
-import { Collection, Message, TextChannel } from "discord.js";
+import { Collection, Message, TextBasedChannel } from "discord.js";
 
 interface GetMessagesResults {
   messages: Message[];
@@ -7,7 +7,7 @@ interface GetMessagesResults {
 
 export class MessageFetcher {
   static async getAllMessages(
-    channel: TextChannel,
+    channel: TextBasedChannel,
     condition: (message: Message) => boolean,
     dateLimit: Date
   ): Promise<GetMessagesResults> {

--- a/src/Services/MessageFetcher.ts
+++ b/src/Services/MessageFetcher.ts
@@ -42,7 +42,7 @@ export class MessageFetcher {
         before: startFromMessage.id,
       })) as Collection<string, Message>;
 
-      totalParsed += messages.size;
+      totalParsed += messages.filter((m) => m.createdAt > dateLimit).size;
 
       // add all valid items to all messages
       allMessages = allMessages.concat(

--- a/src/Services/MessageFetcher.ts
+++ b/src/Services/MessageFetcher.ts
@@ -33,6 +33,7 @@ export class MessageFetcher {
       // get previous 100 messages
       const messages = (await channel.messages.fetch({
         limit: 100,
+        before: startFromMessage.id,
       })) as Collection<string, Message>;
 
       // add all valid items to all messages
@@ -42,7 +43,7 @@ export class MessageFetcher {
           .values()
       );
 
-      // get new limit message
+      // get new earliest message
       startFromMessage = messages.last();
     }
 

--- a/src/Services/MessageFetcher.ts
+++ b/src/Services/MessageFetcher.ts
@@ -1,12 +1,18 @@
 import { Collection, Message, TextChannel } from "discord.js";
 
+interface GetMessagesResults {
+  messages: Message[];
+  totalParsed: number;
+}
+
 export class MessageFetcher {
   static async getAllMessages(
     channel: TextChannel,
     condition: (message: Message) => boolean,
     dateLimit: Date
-  ): Promise<Message[]> {
+  ): Promise<GetMessagesResults> {
     let allMessages: Message[] = [];
+    let totalParsed = 0;
 
     // get first message
     let startFromMessage = (
@@ -17,7 +23,7 @@ export class MessageFetcher {
 
     // return early if there are somehow no messages found
     if (!startFromMessage) {
-      return [];
+      return { messages: [], totalParsed: 0 };
     }
 
     // if condition applies and we are not past date limit, add to array
@@ -36,6 +42,8 @@ export class MessageFetcher {
         before: startFromMessage.id,
       })) as Collection<string, Message>;
 
+      totalParsed += messages.size;
+
       // add all valid items to all messages
       allMessages = allMessages.concat(
         ...messages
@@ -47,6 +55,6 @@ export class MessageFetcher {
       startFromMessage = messages.last();
     }
 
-    return allMessages;
+    return { messages: allMessages, totalParsed };
   }
 }

--- a/src/bots/BotBase.ts
+++ b/src/bots/BotBase.ts
@@ -4,6 +4,7 @@ import Discord, {
   ChannelType,
   GatewayIntentBits,
   IntentsBitField,
+  Message,
   TextBasedChannel,
 } from "discord.js";
 import { NamedLogger } from "../Logger/NamedLogger";
@@ -91,22 +92,48 @@ export abstract class BotBase {
 
   /**
    * Send a message to a channel, with error handling
-   * @param message
+   * @param messageText the text the message should contain
    * @param channel the channel to send to
-   * @returns true if successful, false otherwise
+   * @returns the sent message if successful, otherwise undefined
    */
-  sendMessage(message: string, channel: TextBasedChannel): boolean {
+  async sendMessage(
+    messageText: string,
+    channel: TextBasedChannel
+  ): Promise<Message | undefined> {
     try {
-      channel.send(message);
+      const sentMessage = channel.send(messageText);
 
       if (channel.type === ChannelType.DM) {
         this.logger.log("posted a message to a users DMs");
       } else {
         this.logger.log(`posted a message in #${channel.name}`);
       }
-      return true;
+      return sentMessage;
     } catch (err) {
       this.logger.error("failed to post message");
+      this.logger.error((err as Error).message);
+      return undefined;
+    }
+  }
+
+  /**
+   * Send a message to a channel, with error handling
+   * @param message the message to edit
+   * @param newText the new text
+   * @returns true if successful, false otherwise
+   */
+  async editMessage(message: Message, newText: string): Promise<boolean> {
+    try {
+      await message.edit(newText);
+
+      if (message.channel.type === ChannelType.DM) {
+        this.logger.log("edited a message in a users DMs");
+      } else {
+        this.logger.log(`edited a message in #${message.channel.name}`);
+      }
+      return true;
+    } catch (err) {
+      this.logger.error("failed to edit a message");
       this.logger.error((err as Error).message);
       return false;
     }

--- a/src/bots/WordCounter/WordCounter.ts
+++ b/src/bots/WordCounter/WordCounter.ts
@@ -44,9 +44,28 @@ export class WordCounter extends BotBase {
         // parse their request
         const request = WordCounter.parseRequest(message.content);
 
+        let sentMessage: Message | undefined;
+
+        if (message.channel.type === ChannelType.DM) {
+          sentMessage = await this.sendMessage(
+            `Looking for the word(s) "${request}" in the last year of messages in these DMs...`,
+            message.channel
+          );
+        } else {
+          sentMessage = await this.sendMessage(
+            `Looking for the word(s) "${request}" in the last year of messages in ${message.channel.toString()}...`,
+            message.channel
+          );
+        }
+
+        if (!sentMessage) {
+          return;
+        }
+
         const reply = await WordCounter.prepareReply(message, request, this.id);
 
-        this.sendMessage(reply, message.channel);
+        // edit the sent message
+        this.editMessage(sentMessage, reply);
       }
     });
 
@@ -92,7 +111,7 @@ export class WordCounter extends BotBase {
   ): Promise<string> {
     // make a limit of 7 days
     const dateLimit = new Date();
-    dateLimit.setDate(dateLimit.getDate() - 30);
+    dateLimit.setDate(dateLimit.getDate() - 365);
 
     const { messages, totalParsed } = await MessageFetcher.getAllMessages(
       message.channel as TextChannel,

--- a/src/bots/WordCounter/WordCounter.ts
+++ b/src/bots/WordCounter/WordCounter.ts
@@ -92,9 +92,9 @@ export class WordCounter extends BotBase {
   ): Promise<string> {
     // make a limit of 7 days
     const dateLimit = new Date();
-    dateLimit.setDate(dateLimit.getDate() - 7);
+    dateLimit.setDate(dateLimit.getDate() - 30);
 
-    const messages = await MessageFetcher.getAllMessages(
+    const { messages, totalParsed } = await MessageFetcher.getAllMessages(
       message.channel as TextChannel,
       (m) => WordCounter.checkMessage(m, request, myId),
       dateLimit
@@ -103,11 +103,11 @@ export class WordCounter extends BotBase {
     if (message.channel.type === ChannelType.DM) {
       return `There are ${
         messages.length
-      } messages containing "${request}" since ${dateLimit.toLocaleDateString()} in our correspondence.`;
+      } messages containing "${request}" since ${dateLimit.toLocaleDateString()} (${totalParsed} messages) in our correspondence.`;
     } else {
       return `There are ${
         messages.length
-      } messages containing "${request}" since ${dateLimit.toLocaleDateString()} in #${message.channel.toString()}`;
+      } messages containing "${request}" since ${dateLimit.toLocaleDateString()} (${totalParsed} messages) in ${message.channel.toString()}`;
     }
   }
 }

--- a/src/bots/WordCounter/WordCounter.ts
+++ b/src/bots/WordCounter/WordCounter.ts
@@ -3,9 +3,10 @@ import {
   IntentsBitField,
   Message,
   ChannelType,
-  Collection,
   MessageMentions,
+  TextChannel,
 } from "discord.js";
+import { MessageFetcher } from "../../Services/MessageFetcher";
 import { BotBase } from "../BotBase";
 
 const intents: GatewayIntentBits[] = [
@@ -64,6 +65,7 @@ export class WordCounter extends BotBase {
     return str.replace(/[-/\\^$*+?.()|[\]{}]/g, "\\$&");
   }
 
+  // filter out messages not containing the words
   static checkMessage = (
     message: Message,
     request: string,
@@ -88,21 +90,24 @@ export class WordCounter extends BotBase {
     request: string,
     myId: string
   ): Promise<string> {
-    // get all messages
-    const messages = (await message.channel.messages.fetch({
-      limit: 100,
-    })) as Collection<string, Message>;
+    // make a limit of 7 days
+    const dateLimit = new Date();
+    dateLimit.setDate(dateLimit.getDate() - 7);
 
-    const filtered = messages.filter((m) =>
-      WordCounter.checkMessage(m, request, myId)
+    const messages = await MessageFetcher.getAllMessages(
+      message.channel as TextChannel,
+      (m) => WordCounter.checkMessage(m, request, myId),
+      dateLimit
     );
 
     if (message.channel.type === ChannelType.DM) {
-      return `There are ${filtered.size} messages containing "${request}" in the last 100 messages of our correspondence.`;
+      return `There are ${
+        messages.length
+      } messages containing "${request}" since ${dateLimit.toLocaleDateString()} in our correspondence.`;
     } else {
       return `There are ${
-        filtered.size
-      } messages containing "${request}" in the last 100 messages of ${message.channel.toString()}`;
+        messages.length
+      } messages containing "${request}" since ${dateLimit.toLocaleDateString()} in #${message.channel.toString()}`;
     }
   }
 }

--- a/src/bots/WordCounter/WordCounter.ts
+++ b/src/bots/WordCounter/WordCounter.ts
@@ -86,21 +86,11 @@ export class WordCounter extends BotBase {
     request: string,
     channel: TextBasedChannel
   ): Promise<Message<boolean> | undefined> {
-    let sentMessage: Message | undefined;
+    const messageText = `Looking for the word(s) "${request}" in the last year of messages in ${
+      channel.type === ChannelType.DM ? "these DMs" : channel.toString()
+    }...`;
 
-    if (channel.type === ChannelType.DM) {
-      sentMessage = await this.sendMessage(
-        `Looking for the word(s) "${request}" in the last year of messages in these DMs...`,
-        channel
-      );
-    } else {
-      sentMessage = await this.sendMessage(
-        `Looking for the word(s) "${request}" in the last year of messages in ${channel.toString()}...`,
-        channel
-      );
-    }
-
-    return sentMessage;
+    return await this.sendMessage(messageText, channel);
   }
 
   // filter out messages not containing the words

--- a/src/bots/WordCounter/WordCounter.ts
+++ b/src/bots/WordCounter/WordCounter.ts
@@ -124,8 +124,8 @@ export class WordCounter extends BotBase {
 
     const { messages, totalParsed } = await MessageFetcher.getAllMessages(
       message.channel,
-      (m) => WordCounter.checkMessage(m, request, myId),
-      dateLimit
+      dateLimit,
+      (m) => WordCounter.checkMessage(m, request, myId)
     );
 
     if (message.channel.type === ChannelType.DM) {


### PR DESCRIPTION
Create a function that allows us to fetch more messages than the limit of 100 messages. Then, use it in WordCounter.

This involved chaining several fetches one after the other. This is done through a new service called `MessageFetcher`.

I ended up limiting it to 1 year of lookback for speed reasons. This equates to about 2000 messages for our general channel, which takes around 23 seconds.

Because it takes so long, I changed the approach to posting a message telling the user it is searching, then editing it later.

I may add some more tests later.